### PR TITLE
Cloud Native Protection can now be added without Exocompute

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.76.0 |
-| <a name="provider_polaris"></a> [polaris](#provider\_polaris) | 0.7.2 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.97.1 |
+| <a name="provider_polaris"></a> [polaris](#provider\_polaris) | 0.7.7 |
 
 ## Resources
 
@@ -125,6 +125,7 @@ No requirements.
 | [azurerm_role_definition.cloud_native_protection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.exocompute](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [polaris_azure_exocompute.polaris](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/resources/azure_exocompute) | resource |
+| [polaris_azure_subscription.cloud_native_protection](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/resources/azure_subscription) | resource |
 | [polaris_azure_subscription.polaris](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/resources/azure_subscription) | resource |
 | [azurerm_subnet.polaris](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
@@ -144,15 +145,14 @@ No modules.
 | <a name="input_delete_snapshots_on_destroy"></a> [delete\_snapshots\_on\_destroy](#input\_delete\_snapshots\_on\_destroy) | Should snapshots be deleted when the resource is destroyed. | `bool` | `false` | no |
 | <a name="input_enable_cloud_native_protection"></a> [enable\_cloud\_native\_protection](#input\_enable\_cloud\_native\_protection) | Enable cloud native protection for Azure VMs. | `bool` | n/a | yes |
 | <a name="input_enable_exocompute"></a> [enable\_exocompute](#input\_enable\_exocompute) | Enable Exocompute for the subscription. | `bool` | n/a | yes |
-| <a name="input_exocompute_details"></a> [exocompute\_details](#input\_exocompute\_details) | Region and subnet pair to run Exocompute in. | <pre>map(object({<br>    region                    = string<br>#    subnet_id = string<br>    subnet_name               = string<br>    vnet_name                 = string<br>    vnet_resource_group_name  = string<br>  }))</pre> | n/a | yes |
+| <a name="input_exocompute_details"></a> [exocompute\_details](#input\_exocompute\_details) | Region and subnet pair to run Exocompute in. | <pre>map(object({<br>    region                   = string<br>    subnet_name              = string<br>    vnet_name                = string<br>    vnet_resource_group_name = string<br>  }))</pre> | `{}` | no |
 | <a name="input_polaris_credentials"></a> [polaris\_credentials](#input\_polaris\_credentials) | Full path to credentials file for RSC/Polaris. | `string` | n/a | yes |
-| <a name="input_regions_to_protect"></a> [regions\_to\_protect](#input\_regions\_to\_protect) | List of regions to protect. | `list` | n/a | yes |
+| <a name="input_regions_to_protect"></a> [regions\_to\_protect](#input\_regions\_to\_protect) | List of regions to protect. | `list(string)` | n/a | yes |
 | <a name="input_rsc_service_principal_tenant_domain"></a> [rsc\_service\_principal\_tenant\_domain](#input\_rsc\_service\_principal\_tenant\_domain) | Tenant domain of the Service Principal created in RSC. | `string` | n/a | yes |
 
 ## Outputs
 
 No outputs.
-
 
 <!-- END_TF_DOCS -->
 

--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,7 @@ resource "polaris_azure_subscription" "cloud_native_protection" {
 # false, count will evaluate to 0.
 # Note, the provider currently requires Cloud Native Protection when Exocompute
 # is enabled.
-resource "polaris_azure_subscription" "cloud_native_protection_and_exocompute" {
+resource "polaris_azure_subscription" "polaris" {
   count             = var.enable_cloud_native_protection == true ? var.enable_exocompute == true ? 1 : 0 : 0
   subscription_id   = element(split("/", data.azurerm_subscription.current.id), 2)
   subscription_name = data.azurerm_subscription.current.display_name
@@ -123,7 +123,7 @@ data "azurerm_subnet" "polaris" {
 # Configure the subscription to host Exocompute.
 resource "polaris_azure_exocompute" "polaris" {
   for_each        = { for k, v in var.exocompute_details : k => v if var.enable_exocompute }
-  subscription_id = polaris_azure_subscription.cloud_native_protection_and_exocompute.0.id
+  subscription_id = polaris_azure_subscription.polaris.0.id
   region          = each.value["region"]
   subnet          = data.azurerm_subnet.polaris[each.key].id
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,11 +1,11 @@
 terraform {
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
+      source = "hashicorp/azurerm"
     }
     polaris = {
-      source  = "rubrikinc/polaris"
-    } 
+      source = "rubrikinc/polaris"
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,14 +9,14 @@ variable "azure_service_principal_object_id" {
 }
 
 variable "regions_to_protect" {
-  type        = list
+  type        = list(string)
   description = "List of regions to protect."
 }
 
 variable "delete_snapshots_on_destroy" {
-  type = bool
+  type        = bool
   description = "Should snapshots be deleted when the resource is destroyed."
-  default = false
+  default     = false
 }
 
 variable "enable_cloud_native_protection" {
@@ -31,13 +31,13 @@ variable "enable_exocompute" {
 
 variable "exocompute_details" {
   description = "Region and subnet pair to run Exocompute in."
-  type        = map(object({
-    region                    = string
-#    subnet_id = string
-    subnet_name               = string
-    vnet_name                 = string
-    vnet_resource_group_name  = string
+  type = map(object({
+    region                   = string
+    subnet_name              = string
+    vnet_name                = string
+    vnet_resource_group_name = string
   }))
+  default = {}
 }
 
 variable "polaris_credentials" {


### PR DESCRIPTION
# Description
Made it possible to add a subscription with only Cloud Native Protection by setting `enable_exocompute` to `false` and not specifying `exocompute_details`.

Note, an additional `polaris_azure_subscription` was added and a `count` parameter was added to both of them. This changes the resource instance address which means existing state will need to be manually migrated using the `terraform state mv` command when the module is updated. See https://developer.hashicorp.com/terraform/cli/commands/state/mv for details.

Ran `terraform fmt` for module which updated the formatting of some of the `*.tf` files.

## Related Issue
https://github.com/rubrikinc/terraform-azure-polaris-cloud-native_subscription/issues/1

## How Has This Been Tested?
* Added subscription with only Cloud Native Protection:
  * `enable_cloud_native_protection = true`.
  * `enable_exocompute = false`.
  * `execompute_details` not specified, so using default value of `{}`.
* Added subscription with Cloud Native Protection and Exocompute:
  * `enable_cloud_native_protection = true`.
  * `enable_exocompute = true`.
  * `execompute_details` set to a valid details object.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
