### PR TITLE
Polaris Provider 0.9.0-beta.3 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ There are a few services you'll need in order to get this project off the ground
 ## Usage
 
 ```hcl
+# Add a single subscription in a single region.
+
 terraform {
   required_providers {
     azuread = {
@@ -30,6 +32,18 @@ terraform {
 provider "azuread" {
   tenant_id = "abcdef01-2345-6789-abcd-ef0123456789"
 }
+
+# Initialize the Azure RM provider from the shell environment.
+provider "azurerm" {
+  skip_provider_registration = "true"
+  features {}
+  subscription_id = "01234567-99ab-cdef-0123-456789abcdef"
+}
+
+# Point the provider to the RSC service account to use.
+provider "polaris" {
+  credentials = "../.creds/customer-service-account.json"
+} 
 
 module "polaris-azure-cloud-native_tenant" {
   source                          = "rubrikinc/polaris-cloud-native_tenant/azure"
@@ -74,6 +88,7 @@ module "polaris-azure-cloud-native_subscription" {
 
 ```hcl
 # Add a multiple subscriptions in the same tenant with multiple regions for Exocompute
+
 terraform {
   required_providers {
     azuread = {
@@ -85,6 +100,23 @@ terraform {
     } 
   }
 }
+
+# Configure the Azure Active Directory Provider
+provider "azuread" {
+  tenant_id = "abcdef01-2345-6789-abcd-ef0123456789"
+}
+
+# Initialize the Azure RM provider from the shell environment.
+provider "azurerm" {
+  skip_provider_registration = "true"
+  features {}
+  subscription_id = "01234567-99ab-cdef-0123-456789abcdef"
+}
+
+# Point the provider to the RSC service account to use.
+provider "polaris" {
+  credentials = "../.creds/customer-service-account.json"
+} 
 
 module "polaris-azure-cloud-native_tenant" {
   source                          = "rubrikinc/polaris-cloud-native_tenant/azure"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ module "polaris-azure-cloud-native_subscription" {
   }
   exocompute_details                  = {
     exocompute_config_1 = {
-      region                    = "westus2"
+      region                    = "westus"
       subnet_name               = "subnet1"
       vnet_name                 = "vnet1"
       vnet_resource_group_name  = "vnet-rg"
@@ -80,10 +80,22 @@ module "polaris-azure-cloud-native_subscription_1" {
   }
   exocompute_details                  = {
     exocompute_config_1 = {
-      region                    = "westus2"
+      region                    = "eastus"
       subnet_name               = "subnet1"
       vnet_name                 = "vnet1"
-      vnet_resource_group_name  = "vnet-rg"
+      vnet_resource_group_name  = "vnet-eastus-rg"
+    }
+    exocompute_config_2 = {
+      region                    = "westus"
+      subnet_name               = "subnet2"
+      vnet_name                 = "vnet2"
+      vnet_resource_group_name  = "vnet-westus-rg"
+    }
+    exocompute_config_3 = {
+      region                    = "westus2"
+      subnet_name               = "subnet3"
+      vnet_name                 = "vnet3"
+      vnet_resource_group_name  = "vnet-westus2-rg"
     }
   }
   polaris_credentials                 = "../.creds/customer-service-account.json"
@@ -175,9 +187,7 @@ No modules.
 | <a name="input_azure_service_principal_object_id"></a> [azure\_service\_principal\_object\_id](#input\_azure\_service\_principal\_object\_id) | Azure service principal object id. | `string` | n/a | yes |
 | <a name="input_azure_subscription_id"></a> [azure\_subscription\_id](#input\_azure\_subscription\_id) | Azure subscription id. | `string` | n/a | yes |
 | <a name="input_delete_snapshots_on_destroy"></a> [delete\_snapshots\_on\_destroy](#input\_delete\_snapshots\_on\_destroy) | Should snapshots be deleted when the resource is destroyed. | `bool` | `false` | no |
-| <a name="input_enable_cloud_native_protection"></a> [enable\_cloud\_native\_protection](#input\_enable\_cloud\_native\_protection) | Enable cloud native protection for Azure VMs. | `bool` | n/a | yes |
-| <a name="input_enable_exocompute"></a> [enable\_exocompute](#input\_enable\_exocompute) | Enable Exocompute for the subscription. | `bool` | n/a | yes |
-| <a name="input_exocompute_details"></a> [exocompute\_details](#input\_exocompute\_details) | Region and subnet pair to run Exocompute in. | <pre>map(object({<br>    region                   = string<br>    subnet_name              = string<br>    vnet_name                = string<br>    vnet_resource_group_name = string<br>  }))</pre> | `{}` | no |
+| <a name="input_exocompute_details"></a> [exocompute\_details](#input\_exocompute\_details) | Region and subnet pair to run Exocompute in. | <pre>map(object({<br>    region                   = string<br>    pod_overlay_network_cidr = string<br>    subnet_name              = string<br>    vnet_name                = string<br>    vnet_resource_group_name = string<br>  }))</pre> | `{}` | no |
 | <a name="input_polaris_credentials"></a> [polaris\_credentials](#input\_polaris\_credentials) | Full path to credentials file for RSC/Polaris. | `string` | n/a | yes |
 | <a name="input_regions_to_protect"></a> [regions\_to\_protect](#input\_regions\_to\_protect) | List of regions to protect. | `list(string)` | n/a | yes |
 | <a name="input_rsc_azure_features"></a> [rsc\_azure\_features](#input\_rsc\_azure\_features) | List of Azure features to enable. | `list(string)` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ module "polaris-azure-cloud-native_subscription" {
                                           "CLOUD_NATIVE_PROTECTION",
                                           "EXOCOMPUTE"
                                         ]
-
   rsc_service_principal_tenant_domain = module.polaris-azure-cloud-native_tenant.rsc_service_principal_tenant_domain
 }
 ```
 
 ```hcl
-# Add a multiple subscriptions in the same tenant with multiple regions for Exocompute
+# Add a multiple subscriptions in the same tenant with multiple regions for Exocompute.
+# Using shared Exocompute 
 
 terraform {
   required_providers {
@@ -159,11 +159,8 @@ module "polaris-azure-cloud-native_subscription_1" {
   polaris_credentials                 = "../.creds/customer-service-account.json"
   regions_to_protect                  = ["westus","westus2","eastus"]
   rsc_azure_features                  = [
-                                          "AZURE_SQL_DB_PROTECTION",
-                                          "AZURE_SQL_MI_PROTECTION",
                                           "CLOUD_NATIVE_ARCHIVAL",
                                           "CLOUD_NATIVE_ARCHIVAL_ENCRYPTION",
-                                          "CLOUD_NATIVE_PROTECTION",
                                           "EXOCOMPUTE"
                                         ]
   rsc_service_principal_tenant_domain = module.polaris-azure-cloud-native_tenant.rsc_service_principal_tenant_domain
@@ -174,31 +171,27 @@ module "polaris-azure-cloud-native_subscription_2" {
   
   azure_service_principal_object_id   = module.polaris-azure-cloud-native_tenant.azure_service_principal_object_id
   azure_subscription_id               = "01234567-99ab-cdef-fedc-ba987654"
-  exocompute_details                  = {
-    exocompute_config_1 = {
-      region                    = "eastus"
-      subnet_name               = "subnet2"
-      vnet_name                 = "vnet2"
-      vnet_resource_group_name  = "vnet2-rg"
-    }
-    exocompute_config_2 = {
-      region                    = "westus"
-      subnet_name               = "subnet3"
-      vnet_name                 = "vnet3"
-      vnet_resource_group_name  = "vnet3-rg"
-    }
+  azure_resource_group_name           = "RubrikBackups-RG-DontDelete-terraform"
+  azure_resource_group_region         = "westus"
+  azure_resource_group_tags           = {
+    "Environment" = "Test"
+    "Owner"       = "Terraform" 
   }
   polaris_credentials                 = "../.creds/customer-service-account.json"
   regions_to_protect                  = ["westus","eastus"]
   rsc_azure_features                  = [
-                                          "CLOUD_NATIVE_ARCHIVAL",
-                                          "CLOUD_NATIVE_ARCHIVAL_ENCRYPTION",
                                           "CLOUD_NATIVE_PROTECTION",
+                                          "AZURE_SQL_DB_PROTECTION",
+                                          "AZURE_SQL_MI_PROTECTION",
                                           "EXOCOMPUTE"
                                         ]
   rsc_service_principal_tenant_domain = module.polaris-azure-cloud-native_tenant.rsc_service_principal_tenant_domain
 }
 
+resource "polaris_azure_exocompute" "subscription_2" {
+  cloud_account_id      = module.polaris-azure-cloud-native_subscription_2.polaris_azure_subscription_id
+  host_cloud_account_id = module.polaris-azure-cloud-native_subscription_1.polaris_azure_subscription_id
+}
 ```
 
 <!-- BEGIN_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -104,8 +104,6 @@ module "polaris-azure-cloud-native_subscription_2" {
   
   azure_service_principal_object_id   = module.polaris-azure-cloud-native_tenant.azure_service_principal_object_id
   azure_subscription_id               = "01234567-99ab-cdef-fedc-ba987654"
-  enable_cloud_native_protection      = true
-  enable_exocompute                   = true
   exocompute_details                  = {
     exocompute_config_1 = {
       region                    = "eastus"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,22 @@ There are a few services you'll need in order to get this project off the ground
 ## Usage
 
 ```hcl
-# Add a single subscription
+terraform {
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+    }
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "0.9.0-beta.1"
+    } 
+  }
+}
+
+# Configure the Azure Active Directory Provider
+provider "azuread" {
+  tenant_id = "abcdef01-2345-6789-abcd-ef0123456789"
+}
 
 module "polaris-azure-cloud-native_tenant" {
   source                          = "rubrikinc/polaris-cloud-native_tenant/azure"
@@ -59,6 +74,17 @@ module "polaris-azure-cloud-native_subscription" {
 
 ```hcl
 # Add a multiple subscriptions in the same tenant with multiple regions for Exocompute
+terraform {
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+    }
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "0.9.0-beta.1"
+    } 
+  }
+}
 
 module "polaris-azure-cloud-native_tenant" {
   source                          = "rubrikinc/polaris-cloud-native_tenant/azure"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,16 @@ module "polaris-azure-cloud-native_subscription" {
     }
   }
   polaris_credentials                 = "../.creds/customer-service-account.json"
-  regions_to_protect                  = ["westus","westus2","eastus"]
+  regions_to_protect                  = ["westus"]
+  rsc_azure_features                  = [
+                                          "AZURE_SQL_DB_PROTECTION",
+                                          "AZURE_SQL_MI_PROTECTION",
+                                          "CLOUD_NATIVE_ARCHIVAL",
+                                          "CLOUD_NATIVE_ARCHIVAL_ENCRYPTION",
+                                          "CLOUD_NATIVE_PROTECTION",
+                                          "EXOCOMPUTE"
+                                        ]
+
   rsc_service_principal_tenant_domain = module.polaris-azure-cloud-native_tenant.rsc_service_principal_tenant_domain
 }
 ```
@@ -71,6 +80,14 @@ module "polaris-azure-cloud-native_subscription_1" {
   }
   polaris_credentials                 = "../.creds/customer-service-account.json"
   regions_to_protect                  = ["westus","westus2","eastus"]
+  rsc_azure_features                  = [
+                                          "AZURE_SQL_DB_PROTECTION",
+                                          "AZURE_SQL_MI_PROTECTION",
+                                          "CLOUD_NATIVE_ARCHIVAL",
+                                          "CLOUD_NATIVE_ARCHIVAL_ENCRYPTION",
+                                          "CLOUD_NATIVE_PROTECTION",
+                                          "EXOCOMPUTE"
+                                        ]
   rsc_service_principal_tenant_domain = module.polaris-azure-cloud-native_tenant.rsc_service_principal_tenant_domain
 }
 
@@ -96,7 +113,13 @@ module "polaris-azure-cloud-native_subscription_2" {
     }
   }
   polaris_credentials                 = "../.creds/customer-service-account.json"
-  regions_to_protect                  = ["westus","westus2","eastus"]
+  regions_to_protect                  = ["westus","eastus"]
+  rsc_azure_features                  = [
+                                          "CLOUD_NATIVE_ARCHIVAL",
+                                          "CLOUD_NATIVE_ARCHIVAL_ENCRYPTION",
+                                          "CLOUD_NATIVE_PROTECTION",
+                                          "EXOCOMPUTE"
+                                        ]
   rsc_service_principal_tenant_domain = module.polaris-azure-cloud-native_tenant.rsc_service_principal_tenant_domain
 }
 
@@ -120,17 +143,13 @@ No requirements.
 
 | Name | Type |
 |------|------|
-| [azurerm_role_assignment.cloud_native_protection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.exocompute](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_definition.cloud_native_protection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
-| [azurerm_role_definition.exocompute](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
-| [polaris_azure_exocompute.polaris](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/resources/azure_exocompute) | resource |
-| [polaris_azure_subscription.cloud_native_protection](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/resources/azure_subscription) | resource |
-| [polaris_azure_subscription.polaris](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/resources/azure_subscription) | resource |
+| [azurerm_role_assignment.subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [polaris_azure_subscription.default](https://registry.terraform.io/providers/rubrikinc/polaris/0.9.0-beta.3/docs/resources/azure_subscription) | resource |
 | [azurerm_subnet.polaris](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
-| [polaris_azure_permissions.cloud_native_protection](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/data-sources/azure_permissions) | data source |
-| [polaris_azure_permissions.exocompute](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/data-sources/azure_permissions) | data source |
+| [polaris_azure_permissions.default](https://registry.terraform.io/providers/rubrikinc/polaris/0.9.0-beta.3/docs/data-sources/azure_permissions) | data source |
 
 ## Modules
 
@@ -148,6 +167,7 @@ No modules.
 | <a name="input_exocompute_details"></a> [exocompute\_details](#input\_exocompute\_details) | Region and subnet pair to run Exocompute in. | <pre>map(object({<br>    region                   = string<br>    subnet_name              = string<br>    vnet_name                = string<br>    vnet_resource_group_name = string<br>  }))</pre> | `{}` | no |
 | <a name="input_polaris_credentials"></a> [polaris\_credentials](#input\_polaris\_credentials) | Full path to credentials file for RSC/Polaris. | `string` | n/a | yes |
 | <a name="input_regions_to_protect"></a> [regions\_to\_protect](#input\_regions\_to\_protect) | List of regions to protect. | `list(string)` | n/a | yes |
+| <a name="input_rsc_azure_features"></a> [rsc\_azure\_features](#input\_rsc\_azure\_features) | List of Azure features to enable. | `list(string)` | n/a | yes |
 | <a name="input_rsc_service_principal_tenant_domain"></a> [rsc\_service\_principal\_tenant\_domain](#input\_rsc\_service\_principal\_tenant\_domain) | Tenant domain of the Service Principal created in RSC. | `string` | n/a | yes |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ module "polaris-azure-cloud-native_subscription" {
   
   azure_service_principal_object_id   = module.polaris-azure-cloud-native_tenant.azure_service_principal_object_id
   azure_subscription_id               = "01234567-99ab-cdef-0123-456789abcdef"
-  enable_cloud_native_protection      = true
-  enable_exocompute                   = true
+  azure_resource_group_name           = "RubrikBackups-RG-DontDelete-terraform"
+  azure_resource_group_region         = "westus"
+  azure_resource_group_tags           = {
+    "Environment" = "Test"
+    "Owner"       = "Terraform" 
+  }
   exocompute_details                  = {
     exocompute_config_1 = {
       region                    = "westus2"
@@ -68,8 +72,12 @@ module "polaris-azure-cloud-native_subscription_1" {
   
   azure_service_principal_object_id   = module.polaris-azure-cloud-native_tenant.azure_service_principal_object_id
   azure_subscription_id               = "01234567-99ab-cdef-0123-456789abcdef"
-  enable_cloud_native_protection      = true
-  enable_exocompute                   = true
+  azure_resource_group_name           = "RubrikBackups-RG-DontDelete-terraform"
+  azure_resource_group_region         = "westus"
+  azure_resource_group_tags           = {
+    "Environment" = "Test"
+    "Owner"       = "Terraform" 
+  }
   exocompute_details                  = {
     exocompute_config_1 = {
       region                    = "westus2"
@@ -143,6 +151,8 @@ No requirements.
 
 | Name | Type |
 |------|------|
+| [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_definition.resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
@@ -159,6 +169,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_azure_resource_group_name"></a> [azure\_resource\_group\_name](#input\_azure\_resource\_group\_name) | Name of the Azure resource group to store snapshots and Exocompute artifacts. | `string` | `"Rubrik-Backups-RG-Do-Not-Delete"` | no |
+| <a name="input_azure_resource_group_region"></a> [azure\_resource\_group\_region](#input\_azure\_resource\_group\_region) | Region of the Azure resource group to store snapshots and Exocompute artifacts. | `string` | n/a | yes |
+| <a name="input_azure_resource_group_tags"></a> [azure\_resource\_group\_tags](#input\_azure\_resource\_group\_tags) | Tags to apply to the Azure resource group to store snapshots and Exocompute artifacts. | `map(string)` | `{}` | no |
 | <a name="input_azure_service_principal_object_id"></a> [azure\_service\_principal\_object\_id](#input\_azure\_service\_principal\_object\_id) | Azure service principal object id. | `string` | n/a | yes |
 | <a name="input_azure_subscription_id"></a> [azure\_subscription\_id](#input\_azure\_subscription\_id) | Azure subscription id. | `string` | n/a | yes |
 | <a name="input_delete_snapshots_on_destroy"></a> [delete\_snapshots\_on\_destroy](#input\_delete\_snapshots\_on\_destroy) | Should snapshots be deleted when the resource is destroyed. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -195,7 +195,10 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_polaris_azure_subscription_id"></a> [polaris\_azure\_subscription\_id](#output\_polaris\_azure\_subscription\_id) | n/a |
+
 
 <!-- END_TF_DOCS -->
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ No requirements.
 | [azurerm_role_assignment.subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_definition.resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_user_assigned_identity.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
+| [polaris_azure_exocompute.polaris](https://registry.terraform.io/providers/rubrikinc/polaris/0.9.0-beta.3/docs/resources/azure_exocompute) | resource |
 | [polaris_azure_subscription.default](https://registry.terraform.io/providers/rubrikinc/polaris/0.9.0-beta.3/docs/resources/azure_subscription) | resource |
 | [azurerm_subnet.polaris](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |

--- a/README.md
+++ b/README.md
@@ -148,14 +148,16 @@ module "polaris-azure-cloud-native_subscription_2" {
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_polaris"></a> [polaris](#requirement\_polaris) | =0.9.0-beta.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.97.1 |
-| <a name="provider_polaris"></a> [polaris](#provider\_polaris) | 0.7.7 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_polaris"></a> [polaris](#provider\_polaris) | =0.9.0-beta.3 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,21 @@ resource "polaris_azure_subscription" "default" {
     }
   }
 
+    dynamic "sql_db_protection" {
+    for_each = contains(var.rsc_azure_features, "AZURE_SQL_DB_PROTECTION") ? [1] : []
+    content {
+      permissions           = data.polaris_azure_permissions.default["AZURE_SQL_DB_PROTECTION"].id      
+      regions               =  var.regions_to_protect
+    }
+  }
+
+      dynamic "sql_mi_protection" {
+    for_each = contains(var.rsc_azure_features, "AZURE_SQL_MI_PROTECTION") ? [1] : []
+    content {
+      permissions           = data.polaris_azure_permissions.default["AZURE_SQL_MI_PROTECTION"].id      
+      regions               =  var.regions_to_protect
+    }
+  }
 }
 
 data "azurerm_subnet" "polaris" {

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,6 @@ locals {
   exocompute_regions = flatten([
     for exocompute_detail, details in var.exocompute_details : details.region
   ])
-
-  rsc_instance_fqdn = (element(split("/", jsondecode(file("${var.polaris_credentials}")).access_token_uri), 2))
 }
 
 # The subscription the Azure RM is running with.

--- a/main.tf
+++ b/main.tf
@@ -162,6 +162,7 @@ data "azurerm_subnet" "polaris" {
 resource "polaris_azure_exocompute" "polaris" {
   for_each                  = { for k, v in var.exocompute_details : k => v if contains(var.rsc_azure_features, "EXOCOMPUTE") }
   cloud_account_id          = polaris_azure_subscription.default.id
-  region          = each.value["region"]
+  pod_overlay_network_cidr  = each.value["pod_overlay_network_cidr"]
+  region                    = each.value["region"]
   subnet                    = data.azurerm_subnet.polaris[each.key].id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "polaris_azure_subscription_id" {
+  value = polaris_azure_subscription.default.id
+}

--- a/providers.tf
+++ b/providers.tf
@@ -5,6 +5,7 @@ terraform {
     }
     polaris = {
       source = "rubrikinc/polaris"
+      version = "=0.9.0-beta.3"
     }
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -10,14 +10,7 @@ terraform {
   }
 }
 
-# Initialize the Azure RM provider from the shell environment.
 provider "azurerm" {
-  skip_provider_registration = "true"
   features {}
   subscription_id = var.azure_subscription_id
 }
-
-# Point the provider to the RSC service account to use.
-provider "polaris" {
-  credentials = var.polaris_credentials
-} 

--- a/variables.tf
+++ b/variables.tf
@@ -36,16 +36,6 @@ variable "delete_snapshots_on_destroy" {
   default     = false
 }
 
-variable "enable_cloud_native_protection" {
-  type        = bool
-  description = "Enable cloud native protection for Azure VMs."
-}
-
-variable "enable_exocompute" {
-  type        = bool
-  description = "Enable Exocompute for the subscription."
-}
-
 variable "exocompute_details" {
   description = "Region and subnet pair to run Exocompute in."
   type = map(object({

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,20 @@
+variable "azure_resource_group_name" {
+  type        = string
+  description = "Name of the Azure resource group to store snapshots and Exocompute artifacts."
+  default = "Rubrik-Backups-RG-Do-Not-Delete"
+}
+
+variable "azure_resource_group_region" {
+  type        = string
+  description = "Region of the Azure resource group to store snapshots and Exocompute artifacts."
+}
+
+variable "azure_resource_group_tags" {
+  type        = map(string)
+  description = "Tags to apply to the Azure resource group to store snapshots and Exocompute artifacts."
+  default = {}
+}
+
 variable "azure_subscription_id" {
   type        = string
   description = "Azure subscription id."

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,11 @@ variable "polaris_credentials" {
   description = "Full path to credentials file for RSC/Polaris."
 }
 
+variable "rsc_azure_features" {
+  type        = list(string)
+  description = "List of Azure features to enable."
+}
+
 variable "rsc_service_principal_tenant_domain" {
   type        = string
   description = "Tenant domain of the Service Principal created in RSC."

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,7 @@ variable "exocompute_details" {
   description = "Region and subnet pair to run Exocompute in."
   type = map(object({
     region                   = string
+    pod_overlay_network_cidr = string
     subnet_name              = string
     vnet_name                = string
     vnet_resource_group_name = string


### PR DESCRIPTION
# Description

- [Added support for new tiered permissions model](https://github.com/rubrikinc/terraform-azure-polaris-cloud-native_subscription/commit/5f93d64b3506325c369dafb8c77858e53138d88b)
- [Added support for resource group definition and tagging](https://github.com/rubrikinc/terraform-azure-polaris-cloud-native_subscription/commit/81ba1ecf69118400575d61b34d72b9db70e8d359)
- [Added support for adding Subscriptions for archiving](https://github.com/rubrikinc/terraform-azure-polaris-cloud-native_subscription/commit/63afef86786dfbf3a2974581726307a98c97800a)
- [Added support for adding Azure SQL and Azure MI Subscriptions](https://github.com/rubrikinc/terraform-azure-polaris-cloud-native_subscription/commit/2ee7378538c5882638f52585cfbec3b7fa13626c)
- [Added support for the Exocompute CNI Overlay Network](https://github.com/rubrikinc/terraform-azure-polaris-cloud-native_subscription/commit/f8817d1d9c5533ea53f622a25f8fc8a93bfc6e08)
- [Added mapped Exocompute example](https://github.com/rubrikinc/terraform-azure-polaris-cloud-native_subscription/commit/b3a01364c443ff861ce7cc34bf2aac7c66ecf281)

NOTE: There is a breaking change. The Polaris Provider credentials and Azure credentials must be provided outside the module now. This was done so that the module can be included in loops and use sleep statements. 


## Related Issue

None

## Motivation and Context

Updates to include new features provided by the updated Polaris Provider.

## How Has This Been Tested?

Added subscriptions in RSC using the updated module.

## Screenshots (if appropriate):

None

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
