### PR TITLE
Remove time_sleep resources from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ module "polaris_azure_cloud_native_subscription" {
 - [Centralized Exocompute App](examples/centralized_exocompute)
 - [Centralized Exocompute Host](examples/centralized_exocompute_host)
 
+## Changelog
+
+### v2.1.1
+  * Remove unnecessary `time_sleep` resources from examples.
+
+### v2.1.0
+  * Mark `azure_tenant_id` and `polaris_credentials` input variables as deprecated. They are no longer used by the
+    module and have no replacements.
+  * Move example configuration code from the README.md file to the examples directory.
+
 ## Troubleshooting:
 
 ### Error: Missing Tenant

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -21,24 +21,12 @@ resources.
 | <a name="requirement_polaris"></a> [polaris](#requirement\_polaris) | >=1.0.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >=0.13.0 |
 
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_time"></a> [time](#provider\_time) | >=0.13.0 |
-
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_polaris_azure_cloud_native_subscription"></a> [polaris\_azure\_cloud\_native\_subscription](#module\_polaris\_azure\_cloud\_native\_subscription) | ../.. | n/a |
 | <a name="module_polaris_azure_cloud_native_tenant"></a> [polaris\_azure\_cloud\_native\_tenant](#module\_polaris\_azure\_cloud\_native\_tenant) | rubrikinc/polaris-cloud-native_tenant/azure | n/a |
-
-## Resources
-
-| Name | Type |
-|------|------|
-| [time_sleep.wait_for_tenant](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 
 ## Inputs
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -68,15 +68,6 @@ module "polaris_azure_cloud_native_tenant" {
   source = "rubrikinc/polaris-cloud-native_tenant/azure"
 }
 
-# Give RSC time to process the service principal before adding the subscription.
-resource "time_sleep" "wait_for_tenant" {
-  create_duration = "30s"
-
-  depends_on = [
-    module.polaris_azure_cloud_native_tenant,
-  ]
-}
-
 module "polaris_azure_cloud_native_subscription" {
   source = "../.."
 
@@ -102,9 +93,5 @@ module "polaris_azure_cloud_native_subscription" {
     "CLOUD_NATIVE_ARCHIVAL_ENCRYPTION",
     "CLOUD_NATIVE_PROTECTION",
     "EXOCOMPUTE",
-  ]
-
-  depends_on = [
-    time_sleep.wait_for_tenant,
   ]
 }

--- a/examples/centralized_exocompute/README.md
+++ b/examples/centralized_exocompute/README.md
@@ -44,9 +44,9 @@ resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_azure_service_principal_object_id"></a> [azure\_service\_principal\_object\_id](#input\_azure\_service\_principal\_object\_id) | n/a | `string` | n/a | yes |
+| <a name="input_azure_service_principal_object_id"></a> [azure\_service\_principal\_object\_id](#input\_azure\_service\_principal\_object\_id) | The Azure object id of the service principal used by RSC. | `string` | n/a | yes |
 | <a name="input_azure_subscription_id"></a> [azure\_subscription\_id](#input\_azure\_subscription\_id) | Azure subscription ID. | `string` | n/a | yes |
 | <a name="input_host_cloud_account_id"></a> [host\_cloud\_account\_id](#input\_host\_cloud\_account\_id) | RSC cloud account ID of the Exocompute host subscription. | `string` | n/a | yes |
 | <a name="input_polaris_credentials"></a> [polaris\_credentials](#input\_polaris\_credentials) | RSC service account credentials or the path to a file containing the service account credentials. | `string` | n/a | yes |
-| <a name="input_rsc_service_principal_tenant_domain"></a> [rsc\_service\_principal\_tenant\_domain](#input\_rsc\_service\_principal\_tenant\_domain) | n/a | `string` | n/a | yes |
+| <a name="input_rsc_service_principal_tenant_domain"></a> [rsc\_service\_principal\_tenant\_domain](#input\_rsc\_service\_principal\_tenant\_domain) | The Azure domain name of the service principal used by RSC. | `string` | n/a | yes |
 <!-- END_TF_DOCS -->

--- a/examples/centralized_exocompute/main.tf
+++ b/examples/centralized_exocompute/main.tf
@@ -16,8 +16,8 @@ terraform {
 }
 
 variable "azure_service_principal_object_id" {
-  type = string
-  description = ""
+  type        = string
+  description = "The Azure object id of the service principal used by RSC."
 }
 
 variable "azure_subscription_id" {
@@ -36,8 +36,8 @@ variable "polaris_credentials" {
 }
 
 variable "rsc_service_principal_tenant_domain" {
-  type = string
-  description = ""
+  type        = string
+  description = "The Azure domain name of the service principal used by RSC."
 }
 
 provider "azurerm" {

--- a/examples/centralized_exocompute_host/README.md
+++ b/examples/centralized_exocompute_host/README.md
@@ -27,14 +27,13 @@ resources.
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=3.10.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | >=0.13.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_polaris_azure_cloud_native_subscription"></a> [polaris\_azure\_cloud\_native\_subscription](#module\_polaris\_azure\_cloud\_native\_subscription) | ../.. | n/a |
-| <a name="module_polaris_azure_cloud_native_tenant"></a> [polaris\_azure\_cloud\_native\_tenant](#module\_polaris\_azure\_cloud\_native\_tenant) | ../../../terraform-azure-polaris-cloud-native_tenant | n/a |
+| <a name="module_polaris_azure_cloud_native_tenant"></a> [polaris\_azure\_cloud\_native\_tenant](#module\_polaris\_azure\_cloud\_native\_tenant) | rubrikinc/polaris-cloud-native_tenant/azure | n/a |
 
 ## Resources
 
@@ -44,7 +43,6 @@ resources.
 | [azurerm_resource_group.westus](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_virtual_network.eastus](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [azurerm_virtual_network.westus](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
-| [time_sleep.wait_for_tenant](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 
 ## Inputs
 

--- a/examples/centralized_exocompute_host/main.tf
+++ b/examples/centralized_exocompute_host/main.tf
@@ -87,19 +87,7 @@ resource "azurerm_virtual_network" "westus" {
 }
 
 module "polaris_azure_cloud_native_tenant" {
-  #source = "rubrikinc/polaris-cloud-native_tenant/azure"
-
-  source                         = "../../../terraform-azure-polaris-cloud-native_tenant"
-  azure_application_display_name = "ja-terraform-test1"
-}
-
-# Give RSC time to process the service principal before adding the subscription.
-resource "time_sleep" "wait_for_tenant" {
-  create_duration = "30s"
-
-  depends_on = [
-    module.polaris_azure_cloud_native_tenant,
-  ]
+  source = "rubrikinc/polaris-cloud-native_tenant/azure"
 }
 
 module "polaris_azure_cloud_native_subscription" {
@@ -140,10 +128,6 @@ module "polaris_azure_cloud_native_subscription" {
       pod_overlay_network_cidr = "10.1.0.0/16"
     }
   }
-
-  depends_on = [
-    time_sleep.wait_for_tenant,
-  ]
 }
 
 # The output values can be used with the centralized_exocompute example.


### PR DESCRIPTION
## Motivation and Context

Since we have an explicit dependency between the outputs and a time_sleep resource in the module, there is no longer any need for time_sleep resources in the examples. 

## How Has This Been Tested?

Manually tested the examples.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
